### PR TITLE
Fix order summary buttons

### DIFF
--- a/src/components/Burger/OrderSummary/OrderSummary.js
+++ b/src/components/Burger/OrderSummary/OrderSummary.js
@@ -21,11 +21,11 @@ const orderSummary = (props) => {
       </ul>
       <Button 
         btnType="Danger"
-        clicked={props.cancel}>CANCEL</Button>
+        clicked={props.purchaseCancelled}>CANCEL</Button>
       
       <Button
         btnType="Success"
-        clicked={props.continue}>CONTINUE</Button>
+        clicked={props.purchaseContinued}>CONTINUE</Button>
     </Aux>
   )
 }

--- a/src/components/UI/Button/Button.js
+++ b/src/components/UI/Button/Button.js
@@ -3,8 +3,9 @@ import classes from './Button.module.css';
 
 const button = (props) => (
   <button
-    className={[classes.Button, classes[props.btnType]]}
-    onClick={props.clicked}>{props.children}</button>
+    onClick={props.clicked}
+    className={[classes.Button, classes[props.btnType]].join(' ')}
+    >{props.children}</button>
 )
 
 export default button;

--- a/src/components/UI/Button/Button.module.css
+++ b/src/components/UI/Button/Button.module.css
@@ -1,24 +1,24 @@
 .Button {
-    background-color: transparent;
-    border: none;
-    color: white;
-    outline: none;
-    cursor: pointer;
-    font: inherit;
-    padding: 10px;
-    margin: 10px;
-    font-weight: bold;
+  background-color: transparent;
+  border: none;
+  color: white;
+  outline: none;
+  cursor: pointer;
+  font: inherit;
+  padding: 10px;
+  margin: 10px;
+  font-weight: bold;
 }
 
 .Button:first-of-type {
-    margin-left: 0;
-    padding-left: 0;
+  margin-left: 0;
+  padding-left: 0;
 }
 
 .Success {
-    color: #5C9210;
+  color: #5c9210;
 }
 
 .Danger {
-    color: #944317;
+  color: #944317;
 }

--- a/src/containers/BurgerBuilder/BurgerBuilder.js
+++ b/src/containers/BurgerBuilder/BurgerBuilder.js
@@ -71,7 +71,8 @@ class BurgerBuilder extends Component {
     this.setState({ purchasable: sum > 0 })
   }
 
-  purchaseHandler = () => {
+  purchaseContinuedHandler = () => {
+    alert('you continued!')
     this.setState({ purchasing: true })
   }
 
@@ -92,8 +93,8 @@ class BurgerBuilder extends Component {
             modalClosed={this.purchasedCancelledHandler}>
             <OrderSummary 
               ingredients={this.state.ingredients}
-              cancel={this.purchasedCancelledHandler}
-              continue={this.purchaseHandler} />
+              purchaseCancelled={this.purchasedCancelledHandler}
+              purchaseContinued={this.purchaseContinuedHandler} />
           </Modal>
           <Burger ingredients={this.state.ingredients} />
           <BuildControls
@@ -101,7 +102,7 @@ class BurgerBuilder extends Component {
             fnIngredientRemove={this.removeIngredientHandler}
             disabled={disabledInfo}
             price={this.state.totalPrice}
-            fnOrdered={this.purchaseHandler}
+            fnOrdered={this.purchaseContinuedHandler}
             purchasable={this.state.purchasable}
             purchasing={this.state.purchasing}
             ingredients={this.state.ingredients} />


### PR DESCRIPTION
- Button style classes code was not producing a string of space-separated classes
```
import React from 'react';
import classes from './Button.module.css';

const button = (props) => (
  <button
    onClick={props.clicked}
    className={[classes.Button, classes[props.btnType]].join(' ')}
    >{props.children}</button>
)

export default button;
```